### PR TITLE
[WIP] ETQ Dev, je veux des threads pour les forums

### DIFF
--- a/db/migrations/20190430192450-create-thread.js
+++ b/db/migrations/20190430192450-create-thread.js
@@ -1,0 +1,58 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Thread', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+      },
+      forumId: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Forum',
+          key: 'id',
+        },
+      },
+      authorId: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'User',
+          key: 'id',
+        },
+      },
+      title: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      isSticky: {
+        allowNull: false,
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      isLocked: {
+        allowNull: false,
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      isArchived: {
+        allowNull: false,
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: queryInterface => {
+    return queryInterface.dropTable('Thread');
+  },
+};

--- a/db/seeders/20190430192450-thread.js
+++ b/db/seeders/20190430192450-thread.js
@@ -1,0 +1,31 @@
+module.exports = {
+  up: queryInterface =>
+    queryInterface.bulkInsert(
+      'Forum',
+      [
+        {
+          title: 'Les combats',
+          forumId: 2,
+          authorId: 'd99dead3-923c-583e-96fe-4e18e8299a54',
+          createdAt: '2018-05-14T09:54:16.723Z',
+          updatedAt: '2018-05-15T12:12:53.504Z',
+        },
+        {
+          title: 'Ajouter des micro transactions ?',
+          forumId: 3,
+          authorId: '07f94576-41d7-51f2-88ff-b8b60d9648b8',
+          createdAt: '2018-05-14T09:54:16.723Z',
+          updatedAt: '2018-05-15T12:12:53.504Z',
+        },
+        {
+          title: 'Absent en mai',
+          forumId: 4,
+          authorId: '07f94576-41d7-51f2-88ff-b8b60d9648b8',
+          createdAt: '2018-05-14T09:54:16.723Z',
+          updatedAt: '2018-05-15T12:12:53.504Z',
+        },
+      ],
+      {},
+    ),
+  down: queryInterface => queryInterface.bulkDelete('Forum', null, {}),
+};

--- a/src/models/thread.js
+++ b/src/models/thread.js
@@ -1,0 +1,60 @@
+export default (sequelize, DataTypes) => {
+  const Thread = sequelize.define(
+    'Thread',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+      },
+      forumId: {
+        allowNull: false,
+        type: DataTypes.INTEGER,
+      },
+      userId: {
+        allowNull: false,
+        type: DataTypes.UUIDV4,
+      },
+      title: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+      isSticky: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+      isLocked: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+      isArchived: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+    },
+    {
+      hooks: {
+        // afterCreate: async forum =>
+        // create a Post
+      },
+    },
+  );
+
+  Thread.associate = models => {
+    Thread.belongsTo(models.User, {
+      as: 'author',
+      foreignKey: 'id',
+    });
+
+    Thread.hasMany(models.Thread, {
+      as: 'subThreads',
+      foreignKey: 'parentId',
+    });
+  };
+
+  return Thread;
+};


### PR DESCRIPTION
**Why**

ETQ Dev, je veux pouvoir créer, mettre à jour, lire, et supprimer des threads (`Thread`).


**What**

Un thread est lié à un forum (`Forum`) par la clé étrangère `forumId`. (un forum apossède des threads)
Un thread est lié à des posts (`Post`)  par la clé étrangère `threadId`. (un post appartient à un thread)
Un thread est lié à un author (`User`) par la clé étrangère `threadId`. (un forum possède des threads).
Un thread peut être créé dans un forum si l'utilisateur qui le poste (ie. l'"author") a les permissions en `write`.
Créer un thread trigger aussi la création d'un post.

**How**

Créer un modèle aux propriétés suivantes :

`id`
`forumId`
`title`
`authorId`
`isSticky` 
`isLocked`

Plus tard, quand le model `Post` sera créé, il faudra ajouter au model `Thread` un hook afterCreate qui trigger la création d'un `Post`.
